### PR TITLE
FFI: Make Session an opaque wrapper struct for cbindgen

### DIFF
--- a/driver/src/ffi/command.rs
+++ b/driver/src/ffi/command.rs
@@ -120,7 +120,7 @@ pub unsafe extern "C" fn mongo_run_command(
             action = action.selection_criteria(criteria);
         }
         if let Some(session) = session_ref {
-            action = action.session(session);
+            action = action.session(&mut session.0);
         }
         let result = action.await;
 

--- a/driver/src/ffi/session.rs
+++ b/driver/src/ffi/session.rs
@@ -184,7 +184,7 @@ pub unsafe extern "C" fn mongo_session_start(
     });
 
     match session_result {
-        Ok(session) => Box::into_raw(Box::new(session)),
+        Ok(session) => Box::into_raw(Box::new(Session(session))),
         Err(e) => {
             if !error_out.is_null() {
                 *error_out = Box::into_raw(Box::new(Error::from(&e)));

--- a/driver/src/ffi/types.rs
+++ b/driver/src/ffi/types.rs
@@ -82,10 +82,31 @@ pub struct TlsSettings {
 // C code will only see these as opaque pointers and cannot access their internals
 pub use crate::{
     change_stream::ChangeStream,
-    client::session::ClientSession as Session,
     options::{ReadConcern, ReadPreference, WriteConcern},
     Cursor,
 };
+
+use std::ops::{Deref, DerefMut};
+
+/// Opaque pointer type for Session.
+///
+/// This wraps the Rust ClientSession for FFI. The wrapper is necessary so that
+/// cbindgen generates a proper opaque struct declaration in the C header.
+pub struct Session(pub(super) crate::client::session::ClientSession);
+
+impl Deref for Session {
+    type Target = crate::client::session::ClientSession;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Session {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
 
 /// Raw BSON document.
 #[repr(C)]


### PR DESCRIPTION
Session was previously a type alias for ClientSession, which caused cbindgen to not generate an opaque struct declaration in the C header. This broke jextract generation.

This change creates a proper wrapper struct that cbindgen can export, similar to how MongoClient wraps Client.