### PR TITLE
Add FFI drop operations for database and collection

### DIFF
--- a/driver/src/ffi.rs
+++ b/driver/src/ffi.rs
@@ -14,6 +14,7 @@
 pub mod client;
 pub mod command;
 pub mod cursor;
+pub mod drop;
 pub mod error;
 pub mod find;
 pub mod insert;

--- a/driver/src/ffi/drop.rs
+++ b/driver/src/ffi/drop.rs
@@ -11,18 +11,16 @@ use crate::bson::RawDocumentBuf;
 
 use super::{
     client::MongoClient,
-    error::{Error, InvalidArgumentError},
+    error::Error,
     types::{ContextExt, OperationContext},
-    utils::c_char_to_str,
+    utils::{c_char_to_str, with_void_err_callback},
 };
 
 /// Callback type for drop operations.
 ///
 /// - `userdata`: The userdata pointer passed to the drop function
-/// - `result`: Always null (void operation)
 /// - `error`: Error details (null on success)
-pub type DropCallback =
-    extern "C" fn(userdata: *mut c_void, result: *const (), error: *const Error);
+pub type DropCallback = extern "C" fn(userdata: *mut c_void, error: *const Error);
 
 /// Drop a database asynchronously.
 ///
@@ -40,34 +38,18 @@ pub unsafe extern "C" fn mongo_drop_database(
     callback: DropCallback,
     userdata: *mut c_void,
 ) {
-    if client.is_null() {
-        callback(
-            userdata,
-            std::ptr::null(),
-            &InvalidArgumentError::new("client cannot be null").into(),
-        );
-        return;
-    }
+    use crate::error::Error;
 
-    let db_name_str = match c_char_to_str(db_name) {
-        Ok(Some(s)) => s,
-        Ok(None) => {
-            callback(
-                userdata,
-                std::ptr::null(),
-                &InvalidArgumentError::new("db_name cannot be null").into(),
-            );
-            return;
+    let db = with_void_err_callback!(callback, userdata, || {
+        if client.is_null() {
+            return Err(Error::invalid_argument("client cannot be null"));
         }
-        Err(e) => {
-            callback(userdata, std::ptr::null(), &Error::from(&e));
-            return;
-        }
-    };
+        let db_name_str = c_char_to_str(db_name)?
+            .ok_or_else(|| Error::invalid_argument("db_name cannot be null"))?;
+        Ok((*client).client.database(db_name_str))
+    });
 
     let client_ref = &*client;
-    let db = client_ref.client.database(db_name_str);
-
     let userdata_ptr = userdata as usize;
     let session_ref = context.session();
     client_ref.runtime.spawn(async move {
@@ -79,8 +61,8 @@ pub unsafe extern "C" fn mongo_drop_database(
 
         let userdata = userdata_ptr as *mut c_void;
         match result {
-            Ok(()) => callback(userdata, std::ptr::null(), std::ptr::null()),
-            Err(e) => callback(userdata, std::ptr::null(), &Error::from(&e)),
+            Ok(()) => callback(userdata, std::ptr::null()),
+            Err(e) => callback(userdata, &super::error::Error::from(&e)),
         }
     });
 }
@@ -103,53 +85,23 @@ pub unsafe extern "C" fn mongo_drop_collection(
     callback: DropCallback,
     userdata: *mut c_void,
 ) {
-    if client.is_null() {
-        callback(
-            userdata,
-            std::ptr::null(),
-            &InvalidArgumentError::new("client cannot be null").into(),
-        );
-        return;
-    }
+    use crate::error::Error;
 
-    let db_name_str = match c_char_to_str(db_name) {
-        Ok(Some(s)) => s,
-        Ok(None) => {
-            callback(
-                userdata,
-                std::ptr::null(),
-                &InvalidArgumentError::new("db_name cannot be null").into(),
-            );
-            return;
+    let coll = with_void_err_callback!(callback, userdata, || {
+        if client.is_null() {
+            return Err(Error::invalid_argument("client cannot be null"));
         }
-        Err(e) => {
-            callback(userdata, std::ptr::null(), &Error::from(&e));
-            return;
-        }
-    };
-
-    let coll_name_str = match c_char_to_str(coll_name) {
-        Ok(Some(s)) => s,
-        Ok(None) => {
-            callback(
-                userdata,
-                std::ptr::null(),
-                &InvalidArgumentError::new("coll_name cannot be null").into(),
-            );
-            return;
-        }
-        Err(e) => {
-            callback(userdata, std::ptr::null(), &Error::from(&e));
-            return;
-        }
-    };
+        let db_name_str = c_char_to_str(db_name)?
+            .ok_or_else(|| Error::invalid_argument("db_name cannot be null"))?;
+        let coll_name_str = c_char_to_str(coll_name)?
+            .ok_or_else(|| Error::invalid_argument("coll_name cannot be null"))?;
+        Ok((*client)
+            .client
+            .database(db_name_str)
+            .collection::<RawDocumentBuf>(coll_name_str))
+    });
 
     let client_ref = &*client;
-    let coll = client_ref
-        .client
-        .database(db_name_str)
-        .collection::<RawDocumentBuf>(coll_name_str);
-
     let userdata_ptr = userdata as usize;
     let session_ref = context.session();
     client_ref.runtime.spawn(async move {
@@ -161,9 +113,8 @@ pub unsafe extern "C" fn mongo_drop_collection(
 
         let userdata = userdata_ptr as *mut c_void;
         match result {
-            Ok(()) => callback(userdata, std::ptr::null(), std::ptr::null()),
-            Err(e) => callback(userdata, std::ptr::null(), &Error::from(&e)),
+            Ok(()) => callback(userdata, std::ptr::null()),
+            Err(e) => callback(userdata, &super::error::Error::from(&e)),
         }
     });
 }
-

--- a/driver/src/ffi/drop.rs
+++ b/driver/src/ffi/drop.rs
@@ -52,10 +52,14 @@ pub unsafe extern "C" fn mongo_drop_database(
     let client_ref = &*client;
     let userdata_ptr = userdata as usize;
     let session_ref = context.session();
+    let write_concern = context.write_concern();
     client_ref.runtime.spawn(async move {
         let mut action = db.drop();
         if let Some(session) = session_ref {
             action = action.session(session);
+        }
+        if let Some(wc) = write_concern {
+            action = action.write_concern(wc);
         }
         let result = action.await;
 
@@ -104,10 +108,14 @@ pub unsafe extern "C" fn mongo_drop_collection(
     let client_ref = &*client;
     let userdata_ptr = userdata as usize;
     let session_ref = context.session();
+    let write_concern = context.write_concern();
     client_ref.runtime.spawn(async move {
         let mut action = coll.drop();
         if let Some(session) = session_ref {
             action = action.session(session);
+        }
+        if let Some(wc) = write_concern {
+            action = action.write_concern(wc);
         }
         let result = action.await;
 

--- a/driver/src/ffi/drop.rs
+++ b/driver/src/ffi/drop.rs
@@ -1,0 +1,169 @@
+//! FFI drop operations.
+//!
+//! This module provides C-compatible APIs for dropping databases and collections.
+
+#[cfg(test)]
+mod tests;
+
+use std::{ffi::c_void, os::raw::c_char};
+
+use crate::bson::RawDocumentBuf;
+
+use super::{
+    client::MongoClient,
+    error::{Error, InvalidArgumentError},
+    types::{ContextExt, OperationContext},
+    utils::c_char_to_str,
+};
+
+/// Callback type for drop operations.
+///
+/// - `userdata`: The userdata pointer passed to the drop function
+/// - `result`: Always null (void operation)
+/// - `error`: Error details (null on success)
+pub type DropCallback =
+    extern "C" fn(userdata: *mut c_void, result: *const (), error: *const Error);
+
+/// Drop a database asynchronously.
+///
+/// # Safety
+///
+/// - `client` must be a valid pointer returned from `mongo_client_new`
+/// - `db_name` must be a valid null-terminated C string
+/// - `callback` must be a valid function pointer
+/// - `userdata` can be any value and will be passed to the callback
+#[no_mangle]
+pub unsafe extern "C" fn mongo_drop_database(
+    client: *mut MongoClient,
+    context: *mut OperationContext,
+    db_name: *const c_char,
+    callback: DropCallback,
+    userdata: *mut c_void,
+) {
+    if client.is_null() {
+        callback(
+            userdata,
+            std::ptr::null(),
+            &InvalidArgumentError::new("client cannot be null").into(),
+        );
+        return;
+    }
+
+    let db_name_str = match c_char_to_str(db_name) {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            callback(
+                userdata,
+                std::ptr::null(),
+                &InvalidArgumentError::new("db_name cannot be null").into(),
+            );
+            return;
+        }
+        Err(e) => {
+            callback(userdata, std::ptr::null(), &Error::from(&e));
+            return;
+        }
+    };
+
+    let client_ref = &*client;
+    let db = client_ref.client.database(db_name_str);
+
+    let userdata_ptr = userdata as usize;
+    let session_ref = context.session();
+    client_ref.runtime.spawn(async move {
+        let mut action = db.drop();
+        if let Some(session) = session_ref {
+            action = action.session(session);
+        }
+        let result = action.await;
+
+        let userdata = userdata_ptr as *mut c_void;
+        match result {
+            Ok(()) => callback(userdata, std::ptr::null(), std::ptr::null()),
+            Err(e) => callback(userdata, std::ptr::null(), &Error::from(&e)),
+        }
+    });
+}
+
+/// Drop a collection asynchronously.
+///
+/// # Safety
+///
+/// - `client` must be a valid pointer returned from `mongo_client_new`
+/// - `db_name` must be a valid null-terminated C string
+/// - `coll_name` must be a valid null-terminated C string
+/// - `callback` must be a valid function pointer
+/// - `userdata` can be any value and will be passed to the callback
+#[no_mangle]
+pub unsafe extern "C" fn mongo_drop_collection(
+    client: *mut MongoClient,
+    context: *mut OperationContext,
+    db_name: *const c_char,
+    coll_name: *const c_char,
+    callback: DropCallback,
+    userdata: *mut c_void,
+) {
+    if client.is_null() {
+        callback(
+            userdata,
+            std::ptr::null(),
+            &InvalidArgumentError::new("client cannot be null").into(),
+        );
+        return;
+    }
+
+    let db_name_str = match c_char_to_str(db_name) {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            callback(
+                userdata,
+                std::ptr::null(),
+                &InvalidArgumentError::new("db_name cannot be null").into(),
+            );
+            return;
+        }
+        Err(e) => {
+            callback(userdata, std::ptr::null(), &Error::from(&e));
+            return;
+        }
+    };
+
+    let coll_name_str = match c_char_to_str(coll_name) {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            callback(
+                userdata,
+                std::ptr::null(),
+                &InvalidArgumentError::new("coll_name cannot be null").into(),
+            );
+            return;
+        }
+        Err(e) => {
+            callback(userdata, std::ptr::null(), &Error::from(&e));
+            return;
+        }
+    };
+
+    let client_ref = &*client;
+    let coll = client_ref
+        .client
+        .database(db_name_str)
+        .collection::<RawDocumentBuf>(coll_name_str);
+
+    let userdata_ptr = userdata as usize;
+    let session_ref = context.session();
+    client_ref.runtime.spawn(async move {
+        let mut action = coll.drop();
+        if let Some(session) = session_ref {
+            action = action.session(session);
+        }
+        let result = action.await;
+
+        let userdata = userdata_ptr as *mut c_void;
+        match result {
+            Ok(()) => callback(userdata, std::ptr::null(), std::ptr::null()),
+            Err(e) => callback(userdata, std::ptr::null(), &Error::from(&e)),
+        }
+    });
+}
+

--- a/driver/src/ffi/drop/tests.rs
+++ b/driver/src/ffi/drop/tests.rs
@@ -1,0 +1,4 @@
+//! Tests for FFI drop operations.
+
+// TODO: Add tests for mongo_drop_database and mongo_drop_collection
+

--- a/driver/src/ffi/utils.rs
+++ b/driver/src/ffi/utils.rs
@@ -236,3 +236,28 @@ macro_rules! with_err_callback {
     }};
 }
 pub(super) use with_err_callback;
+
+/// Helper for void callbacks (error-only, no result).
+pub(super) fn with_void_err_callback_internal<ROut>(
+    callback: extern "C" fn(*mut c_void, *const super::error::Error),
+    userdata: *mut c_void,
+    body: impl FnOnce() -> Result<ROut>,
+) -> Option<ROut> {
+    match body() {
+        Ok(v) => Some(v),
+        Err(e) => {
+            callback(userdata, &super::error::Error::from(&e));
+            None
+        }
+    }
+}
+
+macro_rules! with_void_err_callback {
+    ($callback:expr, $userdata:expr, $body:expr) => {{
+        match $crate::ffi::utils::with_void_err_callback_internal($callback, $userdata, $body) {
+            Some(v) => v,
+            None => return,
+        }
+    }};
+}
+pub(super) use with_void_err_callback;


### PR DESCRIPTION
Add mongo_drop_database and mongo_drop_collection FFI functions to support dropping databases and collections from Java FFM bindings.

I need these to run the benchmarks.